### PR TITLE
Add build-essential/compile_time attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -23,7 +23,7 @@ supports 'ubuntu'
 suggests 'pkgutil' # Solaris 2
 
 attribute 'build-essential/compile_time',
-  :display_name => 'Build Essential Compile Time Execution',
-  :description => 'Execute resources at compile time.',
-  :default => false,
-  :recipes => ['build-essential::default']
+  display_name: 'Build Essential Compile Time Execution',
+  description: 'Execute resources at compile time.',
+  default: false,
+  recipes: ['build-essential::default']

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,3 +21,9 @@ supports 'suse'
 supports 'ubuntu'
 
 suggests 'pkgutil' # Solaris 2
+
+attribute 'build-essential/compile_time',
+  :display_name => 'Build Essential Compile Time Execution',
+  :description => 'Execute resources at compile time.',
+  :default => false,
+  :recipes => ['build-essential::default']


### PR DESCRIPTION
Add the cookbook's only attribute to metadata.rb (helps integrators such as RightScale to detect and support attributes).