### PR TITLE
fix metadata to use a string instead of a bool

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,5 +25,5 @@ suggests 'pkgutil' # Solaris 2
 attribute 'build-essential/compile_time',
   display_name: 'Build Essential Compile Time Execution',
   description: 'Execute resources at compile time.',
-  default: "false",
+  default: 'false',
   recipes: ['build-essential::default']

--- a/metadata.rb
+++ b/metadata.rb
@@ -25,5 +25,5 @@ suggests 'pkgutil' # Solaris 2
 attribute 'build-essential/compile_time',
   display_name: 'Build Essential Compile Time Execution',
   description: 'Execute resources at compile time.',
-  default: false,
+  default: "false",
   recipes: ['build-essential::default']


### PR DESCRIPTION
using a bool here is only supported > 11.12.0, and breaks the cookbook for earlier chefs.

fix for https://github.com/opscode-cookbooks/build-essential/issues/56