### PR TITLE
Updates for Solaris 11

### DIFF
--- a/recipes/_solaris2.rb
+++ b/recipes/_solaris2.rb
@@ -33,6 +33,7 @@ when 5.11
     package 'gnu-make'
     package 'gnu-tar'
     package 'pkg-config'
+    package 'ucb'
   end
 else
   raise "Sorry, we don't support Solaris version #{node['platform_version']} at this juncture."

--- a/recipes/_solaris2.rb
+++ b/recipes/_solaris2.rb
@@ -17,19 +17,23 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
-  package 'autoconf'
-  package 'automake'
-  package 'bison'
-  package 'coreutils'
-  package 'flex'
-  package 'gcc4core'
-  package 'gcc4g++'
-  package 'gcc4objc'
-  package 'gcc3core'
-  package 'gcc3g++'
-  package 'ggrep'
-  package 'gmake'
-  package 'gtar'
-  package 'pkgconfig'
+case node['platform_version'].to_f
+when 5.10
+  # install omnibus build essential package
+when 5.11
+  potentially_at_compile_time do
+    package 'autoconf'
+    package 'automake'
+    package 'bison'
+    package 'gnu-coreutils'
+    package 'flex'
+    package 'gcc'
+    package 'gcc-3'
+    package 'gnu-grep'
+    package 'gnu-make'
+    package 'gnu-tar'
+    package 'pkg-config'
+  end
+else
+  raise "Sorry, we don't support Solaris version #{node['platform_version']} at this juncture."
 end


### PR DESCRIPTION
This splits Solaris 10 and Solaris 11 into different sections in the Solaris family recipe and updates the required Sol 11 packages to be the right ones.