### PR TITLE
Fixes #57 - Use "false" instead of false

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -25,5 +25,5 @@ suggests 'pkgutil' # Solaris 2
 attribute 'build-essential/compile_time',
   display_name: 'Build Essential Compile Time Execution',
   description: 'Execute resources at compile time.',
-  default: false,
+  default: 'false',
   recipes: ['build-essential::default']


### PR DESCRIPTION
The intent here is the same - document what the default value of the
attribute is. This has no bearing on anything in Chef itself - in fact
it fixes #57 because older versions of Chef don't have the capability
to have a boolean value for an attribute, that was added in Chef
11.12.0.