### PR TITLE
Use most current attribute data for node

### DIFF
--- a/libraries/timing.rb
+++ b/libraries/timing.rb
@@ -42,8 +42,8 @@ module BuildEssential
     # @param [Proc] block
     #   the thing to eval
     #
-    def potentially_at_compile_time(&block)
-      if compile_time?
+    def potentially_at_compile_time(current_node, &block)
+      if compile_time?(current_node)
         CompileTime.new(self).evaluate(&block)
       else
         instance_eval(&block)
@@ -57,9 +57,9 @@ module BuildEssential
     #
     # @return [true, false]
     #
-    def compile_time?
-      check_for_old_attributes!
-      !!node['build-essential']['compile_time']
+    def compile_time?(current_node)
+      check_for_old_attributes!(current_node)
+      !!current_node['build-essential']['compile_time']
     end
 
     #
@@ -69,8 +69,8 @@ module BuildEssential
     #
     # @return [void]
     #
-    def check_for_old_attributes!
-      unless node['build_essential'].nil?
+    def check_for_old_attributes!(current_node)
+      unless current_node['build_essential'].nil?
         Chef::Log.warn <<-EOH
 node['build_essential'] has been changed to node['build-essential'] to match the
 cookbook name and community standards. I have gracefully converted the attribute
@@ -80,7 +80,7 @@ EOH
         node.default['build-essential'] = node['build_essential']
       end
 
-      unless node['build-essential']['compiletime'].nil?
+      unless current_node['build-essential']['compiletime'].nil?
         Chef::Log.warn <<-EOH
 node['build-essential']['compiletime'] has been deprecated. Please use
 node['build-essential']['compile_time'] instead. I have gracefully converted the

--- a/recipes/_debian.rb
+++ b/recipes/_debian.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'autoconf'
   package 'binutils-doc'
   package 'bison'

--- a/recipes/_fedora.rb
+++ b/recipes/_fedora.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'autoconf'
   package 'bison'
   package 'flex'

--- a/recipes/_freebsd.rb
+++ b/recipes/_freebsd.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'devel/gmake'
   package 'devel/autoconf'
   package 'devel/m4'

--- a/recipes/_mac_os_x.rb
+++ b/recipes/_mac_os_x.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   xcode_command_line_tools 'install'
 end

--- a/recipes/_omnios.rb
+++ b/recipes/_omnios.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'developer/gcc47'
   package 'developer/object-file'
   package 'developer/linker'

--- a/recipes/_rhel.rb
+++ b/recipes/_rhel.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'autoconf'
   package 'bison'
   package 'flex'

--- a/recipes/_smartos.rb
+++ b/recipes/_smartos.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'autoconf'
   package 'binutils'
   package 'build-essential'

--- a/recipes/_solaris2.rb
+++ b/recipes/_solaris2.rb
@@ -28,7 +28,7 @@ when 5.10
   #   SUNWgtar
   #
 when 5.11
-  potentially_at_compile_time do
+  potentially_at_compile_time(node) do
     package 'autoconf'
     package 'automake'
     package 'bison'

--- a/recipes/_suse.rb
+++ b/recipes/_suse.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-potentially_at_compile_time do
+potentially_at_compile_time(node) do
   package 'autoconf'
   package 'bison'
   package 'flex'


### PR DESCRIPTION
Given a recipe like this, the appropriate action will still not run at compile time:
```
node.override['build-essential']['compile_time'] = true
include_recipe 'build-essential'
```

This appears to be due to an issue where the node object referenced in `libraries/timing.rb` is being evaluated before the `node.override` in the recipe itself. Moving the assignment into an attribute file fixes the evaluation order, but it would be nice if this cookbook could still evaluate the node's attribute data based on the freshest node object.

This commit adds the node object as an argument that is passed from the default recipe into the library, no longer relying on the magic of a node variable not defined in the library. As an added bonus, this would allow testing outside of chef, as you could pass a mock node object into the library.